### PR TITLE
select sources by table

### DIFF
--- a/examples/14_Import_Astropy_Table.ipynb
+++ b/examples/14_Import_Astropy_Table.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b6dc38b-1941-4323-9990-f2caf2330325",
+   "metadata": {},
+   "source": [
+    "# Import Astropy Table\n",
+    "This notebook shows how you can import an astropy table a selection region "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04719ca3-019c-4806-9453-0564773099d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from ipyaladin import Aladin\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astroquery.mast import Catalogs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc554318-c26d-4f9e-8f2e-9fd1ec19a005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15efe516-e4e1-448c-a5bc-959215682254",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin = Aladin(\n",
+    "    survey=\"SDSS9 colored\",\n",
+    "    show_coo_grid=True,\n",
+    "    target=\"TRAPPIST-1\",\n",
+    "    coo_frame=\"icrs\",\n",
+    "    fov=0.05,\n",
+    "    height=400,\n",
+    "    samp=True,\n",
+    ")\n",
+    "aladin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5892695a-9915-4835-bd8b-a6f9a049a496",
+   "metadata": {},
+   "source": [
+    "### Add a custom catalog\n",
+    "load a custom catalog that we want to select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8c9b374-ede2-46a1-95c1-6e44072dde20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_name = \"TRAPPIST-1\"\n",
+    "catalog_data = Catalogs.query_region(\n",
+    "    coordinates=SkyCoord.from_name(target_name),\n",
+    "    radius=0.01,  # [deg]\n",
+    "    catalog=\"Panstarrs\",\n",
+    ")\n",
+    "catalog_data.rename_columns([\"raMean\", \"decMean\"], [\"ra\", \"dec\"])\n",
+    "\n",
+    "\n",
+    "aladin.add_table(\n",
+    "    catalog_data, name=\"test-table\", color=\"lime\", shape=\"circle\", source_size=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1d279fc-7a46-4d7e-a4ae-1ff739a6c1a5",
+   "metadata": {},
+   "source": [
+    "Once the catalog is loaded, you can select all of the sources that match on the provided keys. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67fcab46-281d-4012-bd09-d35652be8045",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.select_table(catalog_data, keys=[\"objID\"])"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/14_Import_Astropy_Table.ipynb
+++ b/examples/14_Import_Astropy_Table.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Import Astropy Table\n",
-    "This notebook shows how you can import an astropy table a selection region "
+    "This notebook shows how you can import an astropy table as a selection region "
    ]
   },
   {
@@ -16,7 +16,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "from ipyaladin import Aladin\n",
     "\n",
     "from astropy.coordinates import SkyCoord\n",

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -279,6 +279,8 @@ export default class EventHandler {
       change_colormap: this.messageHandler.handleChangeColormap,
       get_JPG_thumbnail: this.messageHandler.handleGetJPGThumbnail,
       trigger_selection: this.messageHandler.handleTriggerSelection,
+      trigger_selection_by_table:
+        this.messageHandler.handleTriggerSelectionByTable,
       add_table: this.messageHandler.handleAddTable,
     };
 

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -155,6 +155,27 @@ export default class MessageHandler {
     this.aladin.select(selectionType);
   }
 
+  handleTriggerSelectionByTable(msg) {
+    let sources = msg["table"];
+    let keys = msg["keys"];
+    let sourcesByCatalog = this.aladin.view.catalogs
+      .map((cat) => {
+        if (!cat.isShowing) {
+          return;
+        }
+        return cat.getSources().filter((source) =>
+          sources.some((s) =>
+            keys.every((key) => {
+              return s[key] == source.data[key];
+            }),
+          ),
+        );
+      })
+      .filter((n) => n.length);
+
+    this.aladin.view.selectObjects(sourcesByCatalog);
+  }
+
   handleAddTable(msg, buffers) {
     const options = convertOptionNamesToCamelCase(msg["options"] || {});
     const buffer = buffers[0].buffer;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ docs = ["autoapi",
     "sphinx-collections",
     "sphinx-copybutton",
     "sphinx-gallery",
-    "pydata-sphinx-theme"
+    "pydata-sphinx-theme",
+    "pandas"
 ]
 
 # automatically add the dev feature to the default env (e.g., hatch shell)

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -928,6 +928,27 @@ class Aladin(anywidget.AnyWidget):
             raise ValueError("selection_type must be 'circle' or 'rectangle'")
         self.send({"event_name": "trigger_selection", "selection_type": selection_type})
 
+    def select_table(self, table: Table, keys: List[str]) -> None:
+        """Trigger selection of sources included in the user defined table.
+
+        Parameters
+        ----------
+        __________
+        table: Table
+            The astropy table containing the sources the user wishes to select.
+        keys: List[str]
+            The list of keys in the astropy table to use to identifiy a source.
+
+        """
+        table_dict = table.to_pandas()[keys].to_dict("records")
+        self.send(
+            {
+                "event_name": "trigger_selection_by_table",
+                "table": table_dict,
+                "keys": keys,
+            }
+        )
+
     def rectangular_selection(self) -> None:
         """Trigger the rectangular selection tool.
 


### PR DESCRIPTION
## What is changing?
Enabling selection of sources in aladin from an astropy table by unique key(s)

## Why is this change needed?
This change enables both [CST-171](https://jira.stsci.edu/browse/CST-171) and [CST-179](https://jira.stsci.edu/browse/CST-179) by enabling selection of sources defined in an astropy table, and by supporting matching by a user defined set of keys. 

This will enable automation of notebooks in a variety of ways. For our initial use case, this will enable importing and exporting data to and from ipyaladin and jdaviz. 

## How was this tested?
The attached notebook was used to manually test these changes. In the future it would be helpful to have an automated test suite that could be used to test a variety of edge cases. 